### PR TITLE
Remember notification email address using local storage

### DIFF
--- a/src/app/notice-register/notice-register.component.html
+++ b/src/app/notice-register/notice-register.component.html
@@ -95,6 +95,7 @@
             matInput
             placeholder="hoge@example.com"
             required
+            [(ngModel)]="noticeEmail"
             #noticeEmail
             />
           </mat-form-field>

--- a/src/app/notice-register/notice-register.component.ts
+++ b/src/app/notice-register/notice-register.component.ts
@@ -12,6 +12,7 @@ import { TrainService } from '../train.service';
 })
 export class NoticeRegisterComponent implements OnInit {
   public lineName!: string | null;
+  public noticeEmail: string = '';
 
   constructor(
     public trainService: TrainService,
@@ -43,6 +44,7 @@ export class NoticeRegisterComponent implements OnInit {
         cancelDecisionTime,
         noticeEmail
       );
+      window.localStorage.setItem('noticeEmail', noticeEmail);
     } catch (e: any) {
       // メッセージ表示
       this.snackbar.open(
@@ -63,5 +65,6 @@ export class NoticeRegisterComponent implements OnInit {
 
   ngOnInit(): void {
     this.lineName = this.activatedRoute.snapshot.queryParamMap.get('line');
+    this.noticeEmail = window.localStorage.getItem('noticeEmail') || '';
   }
 }


### PR DESCRIPTION
Fixes #9

Add functionality to remember notification email address using local storage.

* Add `noticeEmail` property in `NoticeRegisterComponent` to store the email address.
* Update `ngOnInit` method to retrieve the email address from local storage and set it as the default value in the form.
* Update `register` method to store the email address in local storage after successful registration.
* Add `[(ngModel)]` binding to the `noticeEmail` input field in the template.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Ktraveller285/jr-trainformation/issues/9?shareId=18bb7df2-f730-4ba4-99cd-5d4cc7707e96).